### PR TITLE
fix for 'Cannot read properties of null' error on home page load

### DIFF
--- a/views/layouts/main.handlebars
+++ b/views/layouts/main.handlebars
@@ -57,9 +57,9 @@
     <footer><h3>Footer</h3></footer>
 
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.0/dist/js/bootstrap.bundle.min.js" integrity="sha384-A3rJD856KowSb7dwlZdYEkO39Gagi7vIsF0jrRAoQmDKKtQBHUuLZ9AsSv4jD4Xa" crossorigin="anonymous"></script>
-    <script src="/newProduct.js"></script>
-    <script src="/updateProduct.js"></script>
-    <script src="/updateVendor.js"></script>
+    <script onload="/newProduct.js"></script>
+    <script onload="/updateProduct.js"></script>
+    <script onload="/updateVendor.js"></script>
 
 
 </body>


### PR DESCRIPTION
Adding `onload` prevents errors caused by the script being called before the content is completely loaded.